### PR TITLE
feature: Add video_url and img_url column to porn_video table

### DIFF
--- a/db/migrations/20170822112955_video_migration.php
+++ b/db/migrations/20170822112955_video_migration.php
@@ -26,7 +26,7 @@ class VideoMigration extends AbstractMigration
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    private $tables = [
+    protected $tables = [
         'subscribers', 'porn_videos', 'sites_format'
     ];
 
@@ -62,6 +62,8 @@ class VideoMigration extends AbstractMigration
             ->addColumn('video_id', 'string', array('limit' => $length50, 'comment' => 'xvideo/avgle...'))
             ->addColumn('view_ratings', 'string', array('limit' => $length10, 'comment' => 'the video ratings'))
             ->addColumn('video_title', 'string', array('limit' => $length50, 'comment' => 'the video images title'))
+            ->addColumn('video_url', 'string', array('limit' => $length100, 'comment' => 'the video url'))
+            ->addColumn('img_url', 'string', array('limit' => $length100, 'comment' => 'the video preview image url'))
             ->addColumn('create_date', 'date', array('comment' => 'the date of creating video'))
             ->addIndex(array('video_id'), array('unique' => true))
             ->create();
@@ -76,8 +78,8 @@ class VideoMigration extends AbstractMigration
         $rows = [
             [
               'source'  => 'avgle',
-              'video_url'  => 'avgle.com/video/{video_id}/{video_title}',
-              'video_images'  => 'static.avgle.com/media/videos/tmb2/{video_id}/{image_file_name}'
+              'video_url'  => 'https://avgle.com/video/{video_url}',
+              'video_images'  => 'https://static-clst.avgle.com/videos/{img_url}'
             ],
             [
                 'source'  => 'xvideo',

--- a/scripts/avgle.py
+++ b/scripts/avgle.py
@@ -18,6 +18,8 @@ def insertVideoDb(videos):
     newVideo[PornVideo.video_id] = videos['vid']
     newVideo[PornVideo.view_ratings] = videos['framerate']
     newVideo[PornVideo.video_title] = videos['title']
+    newVideo[PornVideo.video_url] = videos['video_url'].split('/', 4)[4]
+    newVideo[PornVideo.img_url] = videos['preview_url'].split('/', 4)[4]
     newVideo[PornVideo.create_date] = unixTime2DateString(videos['addtime'])
 
     PornVideo.insert(newVideo)\

--- a/scripts/database/model/pornVideo.py
+++ b/scripts/database/model/pornVideo.py
@@ -10,6 +10,8 @@ class PornVideo(BaseModel):
     video_id = CharField()
     view_ratings = CharField()
     video_title = CharField()
+    video_url = CharField()
+    img_url = CharField()
     create_date = DateTimeField()
 
     class Meta:


### PR DESCRIPTION
Add video_url and img_url column to porn_video table.

To run the "vendor/bin/phinx_ migrate -e development -t 20170822112955" to initial the Databse table.
And, run the "python .\scripts\avgle.py" to check data in database is expect.