### PR TITLE
feature: Add video_url and img_url column to porn_video table

### DIFF
--- a/db/migrations/20170822112955_video_migration.php
+++ b/db/migrations/20170822112955_video_migration.php
@@ -26,7 +26,7 @@ class VideoMigration extends AbstractMigration
      * Remember to call "create()" or "update()" and NOT "save()" when working
      * with the Table class.
      */
-    private $tables = [
+    protected $tables = [
         'subscribers', 'porn_videos', 'sites_format'
     ];
 
@@ -61,6 +61,8 @@ class VideoMigration extends AbstractMigration
             ->addColumn('view_numbers', 'integer', array('limit' => MysqlAdapter::INT_MEDIUM, 'comment' => ''))
             ->addColumn('video_id', 'string', array('limit' => $length50, 'comment' => 'xvideo/avgle...'))
             ->addColumn('view_ratings', 'string', array('limit' => $length10, 'comment' => 'the video ratings'))
+            ->addColumn('video_url', 'string', array('limit' => $length100, 'comment' => 'the video url'))
+            ->addColumn('img_url', 'string', array('limit' => $length100, 'comment' => 'the video preview image url'))
             ->addColumn('video_title', 'string', array('limit' => $length50, 'comment' => 'the video images title'))
             ->addColumn('create_date', 'date', array('comment' => 'the date of creating video'))
             ->addIndex(array('video_id'), array('unique' => true))
@@ -76,8 +78,8 @@ class VideoMigration extends AbstractMigration
         $rows = [
             [
               'source'  => 'avgle',
-              'video_url'  => 'avgle.com/video/{video_id}/{video_title}',
-              'video_images'  => 'static.avgle.com/media/videos/tmb2/{video_id}/{image_file_name}'
+              'video_url'  => 'https://avgle.com/video/{video_url}',
+              'video_images'  => 'https://static-clst.avgle.com/videos/{img_url}'
             ],
             [
                 'source'  => 'xvideo',

--- a/scripts/avgle.py
+++ b/scripts/avgle.py
@@ -18,6 +18,8 @@ def insertVideoDb(videos):
     newVideo[PornVideo.video_id] = videos['vid']
     newVideo[PornVideo.view_ratings] = videos['framerate']
     newVideo[PornVideo.video_title] = videos['title']
+    newVideo[PornVideo.video_url] = videos['video_url'].split('/', 4)[4]
+    newVideo[PornVideo.img_url] = videos['preview_url'].split('/', 4)[4]
     newVideo[PornVideo.create_date] = unixTime2DateString(videos['addtime'])
 
     insertAndReplace(newVideo)

--- a/scripts/database/model/pornVideo.py
+++ b/scripts/database/model/pornVideo.py
@@ -10,6 +10,8 @@ class PornVideo(BaseModel):
     video_id = CharField()
     view_ratings = CharField()
     video_title = CharField()
+    video_url = CharField()
+    img_url = CharField()
     create_date = DateTimeField()
 
     class Meta:

--- a/scripts/test/testAvgle.py
+++ b/scripts/test/testAvgle.py
@@ -11,17 +11,23 @@ class AvgleTest(unittest.TestCase):
         avgle.PornVideo.video_id = 'video_id'
         avgle.PornVideo.view_ratings = 'view_ratings'
         avgle.PornVideo.video_title = 'video_title'
+        avgle.PornVideo.video_url = 'video_url'
+        avgle.PornVideo.img_url = 'img_url'
         avgle.PornVideo.create_date = 'create_date'
 
     def testInsertVideoDb(self):
         self.mockPornVideo()
         avgle.insertAndReplace = Mock()
+        videoUrl = 'dPPWUWygiW7/有码高清-abp-540-...'
+        imgUrl = 'tmb12/385343/1.jpg'
 
         videos = {
             'viewnumber': 123,
             'vid': 3345678,
             'framerate': 29.969999,
             'title': 'test title',
+            'video_url': 'https://avgle.com/video/'+videoUrl,
+            'preview_url': 'https://static-clst.avgle.com/videos/'+imgUrl,
             'addtime': 1585894210
         }
 
@@ -32,6 +38,8 @@ class AvgleTest(unittest.TestCase):
             'video_id': 3345678,
             'view_ratings': 29.969999,
             'video_title': 'test title',
+            'video_url': videoUrl,
+            'img_url': imgUrl,
             'create_date': unixTime2DateString(1585894210)
         }
         self.assertEqual(result, expect)


### PR DESCRIPTION
Original url format is avgle.com/video/{video_id}/{video_title}, like "https://avgle.com/video/39271/ミニミニ-つ..."..
But, I call api and return "https://avgle.com/video/hf4MCMvuEMR/有码高清-jul-172..." which format is different.
There also have the same problem in preview image url.
So, I add video_url and img_url column to porn_video table.

To run the "vendor/bin/phinx_ migrate -e development -t 20170822112955" to initial the Databse table.
And, run the "python .\scripts\avgle.py" to check data in database is expect.